### PR TITLE
Distinguishing between JUnit final results and XUnit2 intermediate (rerun) results

### DIFF
--- a/junitparser/junitparser.py
+++ b/junitparser/junitparser.py
@@ -365,22 +365,25 @@ class TestCase(Element):
         return any(isinstance(r, Skipped) for r in self.result)
 
     @property
-    def result(self) -> list[FinalResult]:
+    def result(self) -> List[FinalResult]:
         """A list of :class:`Failure`, :class:`Skipped`, or :class:`Error` objects."""
         return [r for r in self if isinstance(r, FinalResult)]
 
     @result.setter
-    def result(self, value: Union[Result, List[Result]]):
+    def result(self, value: Union[FinalResult, List[FinalResult]]):
+        # Check typing
+        if not (isinstance(value, FinalResult) or
+                isinstance(value, list) and all(isinstance(item, FinalResult) for item in value)):
+            raise ValueError("Value must be either FinalResult or list of FinalResult")
+
         # First remove all existing results
         for entry in self.result:
-            if isinstance(entry, FinalResult):
-                self.remove(entry)
-        if isinstance(value, Result):
+            self.remove(entry)
+        if isinstance(value, FinalResult):
             self.append(value)
-        elif isinstance(value, list):
+        else:
             for entry in value:
-                if isinstance(entry, FinalResult):
-                    self.append(entry)
+                self.append(entry)
 
     @property
     def system_out(self):

--- a/junitparser/xunit2.py
+++ b/junitparser/xunit2.py
@@ -99,8 +99,10 @@ class StackTrace(junitparser.System):
     _tag = "stackTrace"
 
 
-class RerunType(junitparser.Result):
-    _tag = "rerunType"
+class RerunResult(junitparser.Result):
+    """Base class for intermediate / rerun test result (in contrast to JUnit FinalResult)."""
+
+    _tag = None
 
     @property
     def stack_trace(self):
@@ -157,19 +159,19 @@ class RerunType(junitparser.Result):
             self.append(err)
 
 
-class RerunFailure(RerunType):
+class RerunFailure(RerunResult):
     _tag = "rerunFailure"
 
 
-class RerunError(RerunType):
+class RerunError(RerunResult):
     _tag = "rerunError"
 
 
-class FlakyFailure(RerunType):
+class FlakyFailure(RerunResult):
     _tag = "flakyFailure"
 
 
-class FlakyError(RerunType):
+class FlakyError(RerunResult):
     _tag = "flakyError"
 
 
@@ -199,6 +201,6 @@ class TestCase(junitparser.TestCase):
         """<flakyError>"""
         return self._rerun_results(FlakyError)
 
-    def add_rerun_result(self, result: RerunType):
+    def add_rerun_result(self, result: RerunResult):
         """Append a rerun result to the testcase. A testcase can have multiple rerun results."""
         self.append(result)


### PR DESCRIPTION
Improves class hierarchy and naming of results returned by `JUnitXml.TestCase.result`, in contrast to rerun results defined in `xunit2`.

Note: This is a breaking change. Before, `TestCase.result` silently ignored values that were not of type `Result`. This setter method now raises a `ValueError` if values are not of type `FinalResult`.